### PR TITLE
Utilize correct MESSAGE_SIZE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 generate-certificate.py
-.DS_Store
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 generate-certificate.py
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ description = "usb-device driver for CTAPHID"
 categories = ["embedded", "no-std"]
 
 [dependencies]
-ctap-types = "0.1.0"
 ctaphid-dispatch = "0.1.0"
 embedded-time = "0.12"
 delog = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "usb-device driver for CTAPHID"
 categories = ["embedded", "no-std"]
 
 [dependencies]
+ctap-types = "0.1.0"
 ctaphid-dispatch = "0.1.0"
 embedded-time = "0.12"
 delog = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "usb-device driver for CTAPHID"
 categories = ["embedded", "no-std"]
 
 [dependencies]
-ctap-types = { path = "../ctap-types_fork" }
+ctap-types = "0.1.0"
 ctaphid-dispatch = "0.1.0"
 embedded-time = "0.12"
 delog = "0.1.0"
@@ -20,7 +20,7 @@ interchange = "0.3.0"
 serde = { version = "1.0", default-features = false }
 usb-device = "0.2.3"
 ref-swap = "0.1.2"
-trussed = { path = "../trussed_fork" }
+trussed = "0.1.0"
 
 
 [features]
@@ -35,3 +35,4 @@ log-error = []
 
 [patch.crates-io]
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "51e68500d7601d04f884f5e95567d14b9018a6cb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "usb-device driver for CTAPHID"
 categories = ["embedded", "no-std"]
 
 [dependencies]
-ctap-types = "0.1.0"
+ctap-types = { path = "../ctap-types_fork" }
 ctaphid-dispatch = "0.1.0"
 embedded-time = "0.12"
 delog = "0.1.0"
@@ -20,7 +20,7 @@ interchange = "0.3.0"
 serde = { version = "1.0", default-features = false }
 usb-device = "0.2.3"
 ref-swap = "0.1.2"
-trussed = "0.1.0"
+trussed = { path = "../trussed_fork" }
 
 
 [features]
@@ -35,4 +35,3 @@ log-error = []
 
 [patch.crates-io]
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "51e68500d7601d04f884f5e95567d14b9018a6cb" }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,9 +2,5 @@ pub const INTERRUPT_POLL_MILLISECONDS: u8 = 5;
 
 pub const PACKET_SIZE: usize = 64;
 
-// 1200
-// pub const MESSAGE_SIZE: usize = ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE;
-// pub const MESSAGE_SIZE: usize = 3072;
-// 7609 bytes is max message size for ctaphid
-// ctaphid_dispatch::types::Message.len() == 7069;
-pub const MESSAGE_SIZE: usize = 7069;
+// 7609
+pub const MESSAGE_SIZE: usize = PACKET_SIZE - 7 + 128 * (PACKET_SIZE - 5);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,4 +4,7 @@ pub const PACKET_SIZE: usize = 64;
 
 // 1200
 // pub const MESSAGE_SIZE: usize = ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE;
-pub const MESSAGE_SIZE: usize = 3072;
+// pub const MESSAGE_SIZE: usize = 3072;
+// 7609 bytes is max message size for ctaphid
+// ctaphid_dispatch::types::Message.len() == 7069;
+pub const MESSAGE_SIZE: usize = 7069;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,4 @@ pub const INTERRUPT_POLL_MILLISECONDS: u8 = 5;
 
 pub const PACKET_SIZE: usize = 64;
 
-// 1200
-// pub const MESSAGE_SIZE: usize = ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE;
 pub const MESSAGE_SIZE: usize = 3072;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -35,7 +35,7 @@ use usb_device::{
 
 use crate::{
     constants::{
-        // 3072
+        // 7609
         MESSAGE_SIZE,
         // 64
         PACKET_SIZE,

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -234,17 +234,13 @@ impl<'alloc, 'pipe, 'interrupt, Bus: UsbBus> Pipe<'alloc, 'pipe, 'interrupt, Bus
     }
 
     fn cancel_ongoing_activity(&mut self) {
-        // Remove response if it's there
-        if let Some(_response) = self.interchange.take_response() {
-        } else {
+        if matches!(self.state, State::WaitingOnAuthenticator(_)) {
             info_now!("Interrupting request");
             if let Some(Some(i)) = self.interrupt.map(|i| i.load(Ordering::Relaxed)) {
                 info_now!("Loaded some interrupter");
                 i.interrupt();
             }
         }
-
-        self.state = State::Idle;
     }
 
     /// This method handles CTAP packets (64 bytes), until it has assembled


### PR DESCRIPTION
Prior to commit [1d97873](https://github.com/Nitrokey/usbd-ctaphid/commit/1d97873e72d648a7791ffbf46b922198e7a47511), this value was calculated properly. It was then switched to `ctap_types::sizes::REALISTIC_MAX_MESSAGE_SIZE`, which was then removed from the `ctap_types` package, and it was hardcoded at 3072 for an unknown reason in [a2104a2](https://github.com/Nitrokey/usbd-ctaphid/commit/a2104a29b3fd6fe7b74de779f425dedd053200da).

This PR modifies it back to correctly calculating it as a function of the packet size (giving a max of 7609 with a packet size of 64). The hardcoded 3072 value is insufficient for new post-quantum cryptography algorithms, hence the request to increase it.